### PR TITLE
typos: fix nouns and ignore vscode files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,9 @@ typings/
 
 # dotenv environment variables file
 .env
+
+.vscode/
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/

--- a/content/alotbot/body.md
+++ b/content/alotbot/body.md
@@ -6,7 +6,7 @@
 
 A bot to remind your room members how to spell "a lot".
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [reactbot plugin (Github)](https://github.com/maubot/reactbot).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [reactbot plugin (GitHub)](https://github.com/maubot/reactbot).
 
 
 ## Using the bot

--- a/content/blog/2020/10/30/enabling-encryption-for-bots/body.md
+++ b/content/blog/2020/10/30/enabling-encryption-for-bots/body.md
@@ -22,7 +22,7 @@ them out before November 28th.
 Not all bots and bridges on t2bot.io will support encryption out of the gate for various
 reasons, however the few that will are:
 
-* [Gitlab Notifications](/gitlab)
+* [GitLab Notifications](/gitlab)
 * [Trello](/trellobot)
 * [RSS Notifications](/rssbot)
 * [Pollbot](/pollbot)

--- a/content/commitstripbot/body.md
+++ b/content/commitstripbot/body.md
@@ -6,7 +6,7 @@
 
 Posts new CommitStrip comics to your room when they come in. This bot can also be used to find that CommitStrip you were looking for.
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [commitstrip plugin (Github)](https://github.com/maubot/commitstrip).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [commitstrip plugin (GitHub)](https://github.com/maubot/commitstrip).
 
 
 ## Finding a comic

--- a/content/dicebot/body.md
+++ b/content/dicebot/body.md
@@ -6,7 +6,7 @@
 
 Great for RPG rooms or wherever you need a fair dice roll.
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [dice plugin (Github)](https://github.com/maubot/dice).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [dice plugin (GitHub)](https://github.com/maubot/dice).
 
 
 ## Using the bot

--- a/content/docs/encrypted-integrations/integration/gitlab.md
+++ b/content/docs/encrypted-integrations/integration/gitlab.md
@@ -1,7 +1,7 @@
 ---
 layout: public-keys
 icon: mx-gitlab.png
-displayName: Gitlab Notifications
+displayName: GitLab Notifications
 userId: "@gitlab:t2bot.io"
 sessionName: pantalaimon
 sessionId: XOLEHEBUCC

--- a/content/dogebot/body.md
+++ b/content/dogebot/body.md
@@ -6,7 +6,7 @@
 
 This bot is summoned whenever you send a message with "doge", "wow", "much", "many", or "such" in it.
 
-The source code for the bot is available on [Github](https://github.com/CromFr/matrix-doge-bot).
+The source code for the bot is available on [GitHub](https://github.com/CromFr/matrix-doge-bot).
 
 
 ## Using the bot

--- a/content/echobot/body.md
+++ b/content/echobot/body.md
@@ -8,7 +8,7 @@ The echo and ping bots are the same bot and help verify that your homeserver is 
 how your homeserver stacks up against other people, visit [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net) on
 Matrix.
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [echo plugin (Github)](https://github.com/maubot/echo).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [echo plugin (GitHub)](https://github.com/maubot/echo).
 
 
 ## Using the bot

--- a/content/emailbot/body.md
+++ b/content/emailbot/body.md
@@ -7,7 +7,7 @@
 This bot posts a message in your room when it receives an email for that room. This is most used for announcement
 purposes where the room should be receiving newsletters or other emails without the ability to respond.
 
-The source code for the bot is available on [Github](https://github.com/t2bot/matrix-email-bot).
+The source code for the bot is available on [GitHub](https://github.com/t2bot/matrix-email-bot).
 
 
 ## Setting up the bot

--- a/content/factorialbot/body.md
+++ b/content/factorialbot/body.md
@@ -6,7 +6,7 @@
 
 Helps you do math.
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [factorial plugin (Github)](https://github.com/maubot/factorial).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [factorial plugin (GitHub)](https://github.com/maubot/factorial).
 
 
 ## Using the bot

--- a/content/gitlab/body.md
+++ b/content/gitlab/body.md
@@ -2,11 +2,11 @@
 # You don’t need to declare anything in the frontmatter
 ---
 
-# Gitlab Bot
+# GitLab Bot
 
-A bot for showing Gitlab activity in your Matrix room and for interacting with your Gitlab repositories.
+A bot for showing GitLab activity in your Matrix room and for interacting with your GitLab repositories.
 
-The source code for the bot is available on [Github](https://github.com/maubot/gitlab).
+The source code for the bot is available on [GitHub](https://github.com/maubot/gitlab).
 
 
 ## Getting notifications in your room
@@ -25,7 +25,7 @@ To later remove the bot from your room, delete the webhook in gitlab.com and kic
 
 ## Managing your repositories with the bot
 
-The bot has several commands to do things like create issues which require access to your Gitlab account.
+The bot has several commands to do things like create issues which require access to your GitLab account.
 
 1. Invite [@gitlab:t2bot.io](https://matrix.to/#/@gitlab:t2bot.io) to a **private chat**.
 2. Log in to gitlab.com and go to your account settings. Once there, click "Access Tokens" on the left side.

--- a/content/gitlab/index.yml
+++ b/content/gitlab/index.yml
@@ -1,4 +1,4 @@
-title: Gitlab Bot
+title: GitLab Bot
 stylesheet: page
 
 header:

--- a/content/haikubot/body.md
+++ b/content/haikubot/body.md
@@ -6,7 +6,7 @@
 
 When messages look like they fit in the haiku format, this bot does that.
 
-The source code for the bot is available on [Github](https://github.com/turt2live/matrix-haiku-bot).
+The source code for the bot is available on [GitHub](https://github.com/turt2live/matrix-haiku-bot).
 
 
 ## Using the bot

--- a/content/hashtagbot/body.md
+++ b/content/hashtagbot/body.md
@@ -7,7 +7,7 @@
 An absurd usage of the groups/communities API in Matrix: this bot creates a new group whenever it sees a
 hashtag in a message.
 
-The source for this bot is available on [Github](https://github.com/turt2live/matrix-hashtag-bot).
+The source for this bot is available on [GitHub](https://github.com/turt2live/matrix-hashtag-bot).
 
 
 ## Using the bot

--- a/content/hyperbot/body.md
+++ b/content/hyperbot/body.md
@@ -6,7 +6,7 @@
 
 Prefixes single-word nouns with "hyper" for fun.
 
-The source code for the bot is available on [Github](https://github.com/turt2live/matrix-hyper-bot).
+The source code for the bot is available on [GitHub](https://github.com/turt2live/matrix-hyper-bot).
 
 
 ## Using the bot

--- a/content/index/integrations/bots-connected.md
+++ b/content/index/integrations/bots-connected.md
@@ -2,10 +2,10 @@
 layout: featured-integration-section
 spacer: true
 integrations:
-    - name: Gitlab
+    - name: GitLab
       icon: mx-gitlab.png
       target: /gitlab
-      body: "Track your issues, merge requests, and project's progress with the Gitlab bot."
+      body: "Track your issues, merge requests, and project's progress with the GitLab bot."
     - name: Trello
       icon: mx-trello.png
       target: /trellobot

--- a/content/index/integrations/fun.md
+++ b/content/index/integrations/fun.md
@@ -29,7 +29,7 @@ integrations:
     - name: XKCD
       icon: mx-xkcd.png
       target: /xkcdbot
-      body: "Read new KXCD comics when they get released."
+      body: "Read new XKCD comics when they get released."
     - name: CommitStrip
       icon: mx-commitstrip.png
       target: /commitstripbot

--- a/content/mediabot/body.md
+++ b/content/mediabot/body.md
@@ -7,7 +7,7 @@
 Tells you the `mxc://` URI of your uploaded media. Useful for when you need to use a `mxc://` URI instead of a
 plain HTTP URL for referencing images.
 
-The source for this bot is available on [Github](https://github.com/turt2live/matrix-media-bot).
+The source for this bot is available on [GitHub](https://github.com/turt2live/matrix-media-bot).
 
 
 ## Using the bot

--- a/content/redditbot/body.md
+++ b/content/redditbot/body.md
@@ -6,7 +6,7 @@
 
 Provides links to subreddits in a condescending manner.
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [RedditMaubot plugin (Github)](https://github.com/TomCasavant/RedditMaubot).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [RedditMaubot plugin (GitHub)](https://github.com/TomCasavant/RedditMaubot).
 
 
 ## Getting a definition

--- a/content/reminderbot/body.md
+++ b/content/reminderbot/body.md
@@ -6,7 +6,7 @@
 
 Keep track of tasks with the reminder bot.
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [reminder plugin (Github)](https://github.com/maubot/reminder).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [reminder plugin (GitHub)](https://github.com/maubot/reminder).
 
 
 ## Using the bot

--- a/content/rssbot/body.md
+++ b/content/rssbot/body.md
@@ -6,7 +6,7 @@
 
 Subscribes to RSS feeds in your room.
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [rss plugin (Github)](https://github.com/maubot/rss).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [rss plugin (GitHub)](https://github.com/maubot/rss).
 
 
 ## Subscribing to a feed

--- a/content/sedbot/body.md
+++ b/content/sedbot/body.md
@@ -6,7 +6,7 @@
 
 A bot to help you do sed-like replacements on messages.
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [sed plugin (Github)](https://github.com/maubot/sed).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [sed plugin (GitHub)](https://github.com/maubot/sed).
 
 
 ## Using the bot

--- a/content/smilebot/body.md
+++ b/content/smilebot/body.md
@@ -6,7 +6,7 @@
 
 This bot turns that frown upside down.
 
-The source code for the bot is available on [Github](https://github.com/turt2live/matrix-smile-bot).
+The source code for the bot is available on [GitHub](https://github.com/turt2live/matrix-smile-bot).
 
 
 ## Using the bot

--- a/content/topicbot/body.md
+++ b/content/topicbot/body.md
@@ -6,7 +6,7 @@
 
 A bot for updating your room's topic dynamically, such as including the total number of joined members.
 
-The source for this bot is available on [Github](https://github.com/turt2live/matrix-topic-bot).
+The source for this bot is available on [GitHub](https://github.com/turt2live/matrix-topic-bot).
 
 
 ## Using the bot

--- a/content/translatebot/body.md
+++ b/content/translatebot/body.md
@@ -6,7 +6,7 @@
 
 Helps translate words and phrases in your room.
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [translate plugin (Github)](https://github.com/maubot/translate).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [translate plugin (GitHub)](https://github.com/maubot/translate).
 
 
 ## Using the bot

--- a/content/trellobot/body.md
+++ b/content/trellobot/body.md
@@ -6,7 +6,7 @@
 
 A bot for interacting with Trello and being told when some events happen.
 
-The source code for the bot is available on [Github](https://github.com/turt2live/matrix-trello-bot).
+The source code for the bot is available on [GitHub](https://github.com/turt2live/matrix-trello-bot).
 
 
 ## Adding the bot to your room

--- a/content/urbandictionarybot/body.md
+++ b/content/urbandictionarybot/body.md
@@ -6,7 +6,7 @@
 
 Search Urban Dictionary with this bot.
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [UrbanDictionary plugin (Github)](https://github.com/dvdgsng/UrbanMaubot).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [UrbanDictionary plugin (GitHub)](https://github.com/dvdgsng/UrbanMaubot).
 
 
 ## Getting a definition

--- a/content/voyager/body.md
+++ b/content/voyager/body.md
@@ -8,7 +8,7 @@ Voyager is a bot which travels the Matrix network, graphing its journeys. For th
 to, it watches messages for references to other rooms and tries to join them. Every room it discovers
 is shown on [https://voyager.t2bot.io](https://voyager.t2bot.io).
 
-The source code for the bot is available on [Github](https://github.com/turt2live/matrix-voyager-bot).
+The source code for the bot is available on [GitHub](https://github.com/turt2live/matrix-voyager-bot).
 
 
 ## Adding the bot to your room

--- a/content/webhooks/body.md
+++ b/content/webhooks/body.md
@@ -8,7 +8,7 @@ For help with the Webhooks bridge, please visit [#help:t2bot.io](https://matrix.
 on Matrix.
 
 The source code for the bridge is available at [turt2live/matrix-appservice-webhooks](https://github.com/turt2live/matrix-appservice-webhooks)
-on Github.
+on GitHub.
 
 
 ## Creating a webhook for your room

--- a/content/welcomebackbot/body.md
+++ b/content/welcomebackbot/body.md
@@ -6,7 +6,7 @@
 
 A bot for welcoming people back after they have been inactive for a while.
 
-The source code for the bot is available on [Github](https://github.com/turt2live/matrix-welcome-back-bot).
+The source code for the bot is available on [GitHub](https://github.com/turt2live/matrix-welcome-back-bot).
 
 
 ## Configuring the bot in your room

--- a/content/xkcdbot/body.md
+++ b/content/xkcdbot/body.md
@@ -6,7 +6,7 @@
 
 Posts new XKCD comics to your room when they come in. This bot can also be used to find that XKCD you were looking for.
 
-This bot is powered by [maubot (Github)](https://github.com/maubot/maubot) through the [xkcd plugin (Github)](https://github.com/maubot/xkcd).
+This bot is powered by [maubot (GitHub)](https://github.com/maubot/maubot) through the [xkcd plugin (GitHub)](https://github.com/maubot/xkcd).
 
 
 ## Finding a comic


### PR DESCRIPTION
Very minor pull request to fix some typos.

### Typos
* KCXD -> XKCD (What I actually wanted to PR for.)
* Github -> GitHub ([GitHub](https://github.com/), [Wikipedia](https://en.wikipedia.org/wiki/GitHub))
* Gitlab -> GitLab ([GitLab](https://gitlab.com/), [gitlab.org](https://about.gitlab.com/), [Wikipedia](https://en.wikipedia.org/wiki/GitLab))

### .gitignore
Adds VSC files based on the [github/gitignore](https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore) repository.